### PR TITLE
Restructure CMakeLists.txt to be suitable for CPM.cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,52 +5,61 @@ project(dylib)
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR})
-set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR})
-
-option(BUILD_TESTS "when set to ON, build unit tests" OFF)
-
-include_directories(include)
-
-if(BUILD_TESTS)
-
-find_package(googletest QUIET)
-include(FetchContent)
-FetchContent_Declare(
-    googletest
-    URL https://github.com/google/googletest/archive/refs/tags/release-1.11.0.zip
-)
-set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-FetchContent_MakeAvailable(googletest)
-
+add_library(dylib INTERFACE)
+target_include_directories(dylib INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 if(UNIX)
-    add_compile_options(-Wall -Wextra -Weffc++)
-elseif(WIN32)
-    add_compile_options(/W4)
+    target_link_libraries(dylib INTERFACE dl)
 endif()
 
-add_library(dynamic_lib SHARED tests/dynamic_lib.cpp)
-set_target_properties(dynamic_lib PROPERTIES PREFIX "")
+if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+    # Project is configured as root (not subdirectory) -> include tests
+    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR})
+    set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR})
 
-enable_testing()
+    option(BUILD_TESTS "when set to ON, build unit tests" OFF)
 
-add_executable(unit_tests tests/tests.cpp)
+    if(BUILD_TESTS)
 
-if(UNIX AND NOT APPLE)
-    add_compile_options(--coverage)
-	target_link_libraries(unit_tests PRIVATE gcov)
-endif()
+    find_package(googletest QUIET)
+    include(FetchContent)
+    FetchContent_Declare(
+        googletest
+        URL https://github.com/google/googletest/archive/refs/tags/release-1.11.0.zip
+    )
+    set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+    FetchContent_MakeAvailable(googletest)
 
-if(UNIX)
-    target_link_libraries(unit_tests PRIVATE dl)
-endif()
+    if(UNIX)
+        add_compile_options(-Wall -Wextra -Weffc++)
+    elseif(WIN32)
+        add_compile_options(/W4)
+    endif()
 
-target_link_libraries(unit_tests PRIVATE gtest_main)
+    add_library(dynamic_lib SHARED tests/dynamic_lib.cpp)
+    set_target_properties(dynamic_lib PROPERTIES PREFIX "")
+    target_link_libraries(dynamic_lib PRIVATE dylib)
 
-include(GoogleTest)
+    enable_testing()
 
-gtest_discover_tests(unit_tests)
+    add_executable(unit_tests tests/tests.cpp)
+    target_link_libraries(unit_tests PRIVATE dylib)
 
-add_dependencies(unit_tests dynamic_lib)
+    if(UNIX AND NOT APPLE)
+        add_compile_options(--coverage)
+        target_link_libraries(unit_tests PRIVATE gcov)
+    endif()
 
+    if(UNIX)
+        target_link_libraries(unit_tests PRIVATE dl)
+    endif()
+
+    target_link_libraries(unit_tests PRIVATE gtest_main)
+
+    include(GoogleTest)
+
+    gtest_discover_tests(unit_tests)
+
+    add_dependencies(unit_tests dynamic_lib)
+
+    endif()
 endif()


### PR DESCRIPTION
# Description
First of all, thanks for making this library!

I'm using [CMake Package Manager ](https://github.com/cpm-cmake/CPM.cmake) (CPM.cmake) to add libraries like this one to CMake projects. CPM.cmake makes adding external libraries easy when the library has a CMake build system that works
well when added as a subdirectory.

This pull request makes a minor change to the CMake build system so that tests and installation logic are not included when the project is **not** the root project (i.e. added using `add_subdirectory`). The advantage of doing this is that projects using this library will not accidentally build and run tests or install files defined by this project.

I'm open to feedback if this doesn't work well with existing CMake workflows.

# Changes include

- [x] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [x] I have tested this code
- [x] I have added sufficient documentation in the code