### PR TITLE
fix: ambiguity inside documentation regarding references vs values for get_variable()

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,9 @@ Get a global variable from the dynamic library currently loaded in the object
 
 dylib lib("./dynamic_lib.so");
 
-// Get the function adder
+// Get the function adder (get_function<T> will return std::function<T>)
 
-std::function<double(double, double)> adder = lib.get_function<double(double, double)>("adder");
+auto adder = lib.get_function<double(double, double)>("adder");
 
 // Get the global variable pi_value
 

--- a/README.md
+++ b/README.md
@@ -89,11 +89,11 @@ dylib lib("./dynamic_lib.so");
 
 // Get the function adder
 
-auto adder = lib.get_function<double(double, double)>("adder");
+std::function<double(double, double)> adder = lib.get_function<double(double, double)>("adder");
 
 // Get the global variable pi_value
 
-double pi = lib.get_variable<double>("pi_value");
+const double &pi = lib.get_variable<double>("pi_value");
 
 // Use the function adder with pi_value
 
@@ -136,7 +136,7 @@ Those exceptions inherit from `dylib::exception`
 ```c++
 try {
     dylib lib("./dynamic_lib.so");
-    double pi_value = lib.get_variable<double>("pi_value");
+    const double &pi_value = lib.get_variable<double>("pi_value");
     std::cout << pi_value << std::endl;
 }
 catch (const dylib::exception &e) {


### PR DESCRIPTION
# Description

fix: ambiguity inside documentation regarding references vs values for `get_variable()`

# Changes include

- [X] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [X] I have assigned this PR to myself
- [X] I have added at least 1 reviewer
- [X] I have tested this code
- [X] I have added sufficient documentation in the code