### PR TITLE
Fix test suite

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,16 +12,6 @@ jobs:
             fail-fast: false
             matrix:
                 os: [windows-latest, macos-latest, ubuntu-latest]
-                include:
-                  - os: windows-latest
-                    bin: unit_tests.exe
-                    dir: ./Debug/
-                  - os: ubuntu-latest
-                    bin: unit_tests
-                    dir: ./
-                  - os: macos-latest
-                    bin: unit_tests
-                    dir: ./
 
         name: ${{ matrix.os }}
         runs-on: ${{ matrix.os }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -36,7 +36,8 @@ jobs:
               run: cmake --build build
 
             - name: Run Unit Tests
-              run: ${{ matrix.dir }}${{ matrix.bin }}
+              working-directory: build
+              run: ctest
 
             - name: Send Coverage to codecov.io
               if: ${{ matrix.os == 'ubuntu-latest' }}
@@ -62,6 +63,7 @@ jobs:
               run: cmake --build build
 
             - name: Run Unit Tests with Valgrind
+              working-directory: build
               run: valgrind --leak-check=full --show-leak-kinds=all --error-exitcode=1 ./unit_tests
 
     linter:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,8 +12,8 @@ if(UNIX)
 endif()
 
 if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
-    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR})
-    set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR})
+    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR})
+    set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR})
 
     option(BUILD_TESTS "when set to ON, build unit tests" OFF)
 
@@ -49,6 +49,6 @@ if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
         endif()
 
         include(GoogleTest)
-        gtest_discover_tests(unit_tests)
+        gtest_discover_tests(unit_tests WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
     endif()
 endif()


### PR DESCRIPTION
# Description

- Binaries and dynamic libraries are now located inside `${PROJECT_BINARY_DIR}` instead of `${PROJECT_SOURCE_DIR}`
- Working directory of unit test is now correctly set
- Change on CI file to map those changes

# Changes include

- [X] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [X] I have assigned this PR to myself
- [X] I have added at least 1 reviewer
- [X] I have tested this code
- [X] I have added sufficient documentation in the code