### PR TITLE
Fix compiler warnings when initializing extern variables

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -9,8 +9,11 @@ The functions and variables of our forthcoming dynamic library are located insid
 #include <iostream>
 #include "dylib.hpp"
 
-DYLIB_API double pi_value = 3.14159;
-DYLIB_API void *ptr = (void *)1;
+DYLIB_API double pi_value;
+DYLIB_API void *ptr;
+
+double pi_value = 3.14159;
+void *ptr = (void *)1;
 
 DYLIB_API double adder(double a, double b) {
     return a + b;

--- a/example/lib.cpp
+++ b/example/lib.cpp
@@ -1,8 +1,11 @@
 #include <iostream>
 #include "dylib.hpp"
 
-DYLIB_API double pi_value = 3.14159;
-DYLIB_API void *ptr = (void *)1;
+DYLIB_API double pi_value;
+DYLIB_API void *ptr;
+
+double pi_value = 3.14159;
+void *ptr = (void *)1;
 
 DYLIB_API double adder(double a, double b) {
     return a + b;

--- a/tests/lib.cpp
+++ b/tests/lib.cpp
@@ -1,8 +1,8 @@
 #include <iostream>
 #include "dylib.hpp"
 
-DYLIB_API double pi_value = 3.14159;
-DYLIB_API void *ptr = (void *)1;
+DYLIB_API inline double pi_value = 3.14159;
+DYLIB_API inline void *ptr = (void *)1;
 
 DYLIB_API double adder(double a, double b) {
     return a + b;

--- a/tests/lib.cpp
+++ b/tests/lib.cpp
@@ -1,8 +1,11 @@
 #include <iostream>
 #include "dylib.hpp"
 
-DYLIB_API inline double pi_value = 3.14159;
-DYLIB_API inline void *ptr = (void *)1;
+DYLIB_API double pi_value;
+DYLIB_API void *ptr;
+
+pi_value = 3.14159;
+ptr = (void *)1;
 
 DYLIB_API double adder(double a, double b) {
     return a + b;

--- a/tests/lib.cpp
+++ b/tests/lib.cpp
@@ -4,8 +4,8 @@
 DYLIB_API double pi_value;
 DYLIB_API void *ptr;
 
-pi_value = 3.14159;
-ptr = (void *)1;
+double pi_value = 3.14159;
+void *ptr = (void *)1;
 
 DYLIB_API double adder(double a, double b) {
     return a + b;


### PR DESCRIPTION
# Description

fix: gcc warnings when initializing extern variables

# Changes include

- [X] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [X] I have assigned this PR to myself
- [X] I have added at least 1 reviewer
- [X] I have tested this code
- [X] I have added sufficient documentation in the code