### PR TITLE
get_function return type changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,13 +87,13 @@ Get a global variable from the dynamic library currently loaded in the object
 
 dylib lib("./dynamic_lib.so");
 
-// Get the function adder
+// Get the function adder (get_function<T> will return T*)
 
-auto &adder = lib.get_function<double(double, double)>("adder");
+auto adder = lib.get_function<double(double, double)>("adder");
 
-// Get the variable pi_value
+// Get the variable pi_value (get_variable<T> will return T&)
 
-double &pi = lib.get_variable<double>("pi_value");
+double pi = lib.get_variable<double>("pi_value");
 
 // Use the function adder with pi_value
 

--- a/include/dylib.hpp
+++ b/include/dylib.hpp
@@ -148,10 +148,10 @@ public:
      *  @param T the template argument must be the function prototype to get
      *  @param name the symbol name of a function to get from the dynamic library
      *
-     *  @return a reference to the requested function
+     *  @return a pointer to the requested function
      */
     template<typename T>
-    T &get_function(const char *name) const {
+    T *get_function(const char *name) const {
         if (!name)
             throw symbol_error(get_symbol_error("(nullptr)"));
         if (!m_handle)
@@ -159,11 +159,11 @@ public:
         auto sym = _get_symbol(m_handle, name);
         if (!sym)
             throw symbol_error(get_symbol_error(name));
-        return *reinterpret_cast<T *>(sym);
+        return reinterpret_cast<T *>(sym);
     }
 
     template<typename T>
-    T &get_function(const std::string &name) const {
+    T *get_function(const std::string &name) const {
         return get_function<T>(name.c_str());
     }
 


### PR DESCRIPTION
`get_function` now returns a pointer on the requested function instead of a reference