### PR TITLE
Version 2.1.0

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -3,74 +3,96 @@ name: CI
 on: [push, pull_request]
 
 defaults:
-    run:
-        shell: bash
+  run:
+    shell: bash
 
 jobs:
-    unit_tests:
-        strategy:
-            fail-fast: false
-            matrix:
-                os: [windows-latest, macos-latest, ubuntu-latest]
+  unit_tests_cpp11:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, macos-latest, ubuntu-latest]
 
-        name: ${{ matrix.os }}
-        runs-on: ${{ matrix.os }}
+    name: ${{ matrix.os }} (C++11)
+    runs-on: ${{ matrix.os }}
 
-        steps:
-            - uses: actions/checkout@v2
+    steps:
+      - uses: actions/checkout@v2
 
-            - name: Generate project files
-              run: cmake . -B build -DBUILD_TESTS=ON
+      - name: Generate project files
+        run: cmake . -B build -DCMAKE_CXX_STANDARD=11 -DBUILD_TESTS=ON
 
-            - name: Build dynamic library and unit tests
-              run: cmake --build build
+      - name: Build dynamic library and unit tests
+        run: cmake --build build
 
-            - name: Run unit tests
-              working-directory: build
-              run: ctest
+      - name: Run unit tests
+        working-directory: build
+        run: ctest
 
-            - name: Generate code coverage
-              if: ${{ matrix.os == 'ubuntu-latest' }}
-              run: gcov -abcfu build/CMakeFiles/unit_tests.dir/tests/tests.cpp.gcda
+  unit_tests_cpp17:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, macos-latest, ubuntu-latest]
 
-            - name: Send coverage to codecov.io
-              if: ${{ matrix.os == 'ubuntu-latest' }}
-              uses: codecov/codecov-action@v2
-              with:
-                files: dylib.hpp.gcov
+    name: ${{ matrix.os }} (C++17)
+    runs-on: ${{ matrix.os }}
 
-    memory_check:
-        name: memory check
-        runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
 
-        steps:
-            - uses: actions/checkout@v2
+      - name: Generate project files
+        run: cmake . -B build -DCMAKE_CXX_STANDARD=17 -DBUILD_TESTS=ON
 
-            - name: Update packages
-              run: sudo apt update
+      - name: Build dynamic library and unit tests
+        run: cmake --build build
 
-            - name: Install valgrind
-              run: sudo apt install -y valgrind
+      - name: Run unit tests
+        working-directory: build
+        run: ctest
 
-            - name: Generate tests build file
-              run: cmake . -B build -DBUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Debug
+      - name: Generate code coverage
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        run: gcov -abcfu build/CMakeFiles/unit_tests.dir/tests/tests.cpp.gcda
 
-            - name: Build unit tests
-              run: cmake --build build
+      - name: Send coverage to codecov.io
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        uses: codecov/codecov-action@v2
+        with:
+          files: dylib.hpp.gcov
 
-            - name: Run unit tests with valgrind
-              working-directory: build
-              run: valgrind --leak-check=full --show-leak-kinds=all --error-exitcode=1 ./unit_tests
+  memory_check:
+    name: memory check
+    runs-on: ubuntu-latest
 
-    linter:
-        name: linter
-        runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
 
-        steps:
-            - uses: actions/checkout@v2
+      - name: Update packages
+        run: sudo apt update
 
-            - name: Install cpplint
-              run: pip install cpplint
+      - name: Install valgrind
+        run: sudo apt install -y valgrind
 
-            - name: Run cpplint
-              run: cpplint --linelength=140 --filter=-whitespace/indent,-whitespace/parens include/dylib.hpp
+      - name: Generate tests build file
+        run: cmake . -B build -DCMAKE_CXX_STANDARD=17 -DBUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Debug
+
+      - name: Build unit tests
+        run: cmake --build build
+
+      - name: Run unit tests with valgrind
+        working-directory: build
+        run: valgrind --leak-check=full --show-leak-kinds=all --error-exitcode=1 ./unit_tests
+
+  linter:
+    name: linter
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install cpplint
+        run: pip install cpplint
+
+      - name: Run cpplint
+        run: cpplint --linelength=140 --filter=-whitespace/indent,-whitespace/parens include/dylib.hpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,9 @@ cmake_minimum_required(VERSION 3.14)
 
 project(dylib CXX)
 
-set(CMAKE_CXX_STANDARD 11)
+if(NOT "${CMAKE_CXX_STANDARD}")
+  set(CMAKE_CXX_STANDARD 11)
+endif()
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 add_library(dylib INTERFACE)
@@ -49,6 +51,6 @@ if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
         endif()
 
         include(GoogleTest)
-        gtest_discover_tests(unit_tests WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
+        gtest_discover_tests(unit_tests PROPERTIES TIMEOUT 600 WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
     endif()
 endif()

--- a/README.md
+++ b/README.md
@@ -70,19 +70,19 @@ dylib lib("./libs", "foo");
 dylib lib("/usr/lib", "foo");
 ```
 
-The `dylib` class will automatically add os decorations to the library name, but you can disable that by setting `decorations` parameter to false
+The `dylib` class will automatically add the filename decorations of the current os to the library name, but you can disable that by setting `decorations` parameter to `dylib::no_filename_decorations`
 ```c++
 // Windows -> "foo.dll"
-// MacOS:  -> "libfoo.dylib"
-// Linux:  -> "libfoo.so"
+// MacOS   -> "libfoo.dylib"
+// Linux   -> "libfoo.so"
 
 dylib lib("foo");
 
 // Windows -> "foo.lib"
-// MacOS:  -> "foo.lib"
-// Linux:  -> "foo.lib"
+// MacOS   -> "foo.lib"
+// Linux   -> "foo.lib"
 
-dylib lib("foo.lib", false);
+dylib lib("foo.lib", dylib::no_filename_decorations);
 ```
 
 ## Get a function or a variable 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 <p align="center">
-  <img height="200" src="https://repository-images.githubusercontent.com/354428648/5ef81a00-95b1-11eb-88a1-e1760bd99ab2" alt="dylib"/>
+  <img height=60% width=350 src="https://repository-images.githubusercontent.com/354428648/5ef81a00-95b1-11eb-88a1-e1760bd99ab2" alt="dylib"/>
 </p>
 
 <p align="center">
-  <a href="https://github.com/martin-olivier/dylib/releases/tag/v2.0.0">
-    <img src="https://img.shields.io/badge/Version-2.0.0-blue.svg" alt="version"/>
+  <a href="https://github.com/martin-olivier/dylib/releases/tag/v2.1.0">
+    <img src="https://img.shields.io/badge/Version-2.1.0-blue.svg" alt="version"/>
   </a>
   <a href="https://github.com/martin-olivier/dylib/blob/main/LICENSE">
     <img src="https://img.shields.io/badge/License-MIT-orange.svg" alt="license"/>
@@ -41,13 +41,13 @@ include(FetchContent)
 FetchContent_Declare(
     dylib
     GIT_REPOSITORY "https://github.com/martin-olivier/dylib"
-    GIT_TAG        "v2.0.0"
+    GIT_TAG        "v2.1.0"
 )
 
 FetchContent_MakeAvailable(dylib)
 ```
 
-You can also click [HERE](https://github.com/martin-olivier/dylib/releases/download/v2.0.0/dylib.hpp) to download the `dylib` header file.  
+You can also click [HERE](https://github.com/martin-olivier/dylib/releases/download/v2.1.0/dylib.hpp) to download the `dylib` header file.  
 
 # Documentation
 
@@ -61,11 +61,11 @@ dylib lib("foo");
 ```
 The `dylib` class can also load a dynamic library from a specific path
 ```c++
-// Load "foo" lib from relative path "./libs"
+// Load "foo" library from relative path "./libs"
 
 dylib lib("./libs", "foo");
 
-// Load "foo" lib from full path "/usr/lib"
+// Load "foo" library from full path "/usr/lib"
 
 dylib lib("/usr/lib", "foo");
 ```
@@ -113,15 +113,20 @@ double result = adder(pi, pi);
 ## Miscellaneous tools
 
 `has_symbol`  
-Returns true if the symbol passed as parameter exists in the dynamic library, false otherwise  
+Returns true if the symbol passed as parameter exists in the dynamic library, false otherwise
+
+`get_symbol`  
+Get a symbol from the dynamic library currently loaded in the object  
 
 `native_handle`  
-Returns the dynamic library handle  
+Returns the dynamic library handle
 ```c++
 void example(dylib &lib)
 {
     if (lib.has_symbol("GetModule"))
-        std::cout << "GetModule symbol has been found" << std::endl;
+        dylib::native_symbol_type sym = lib.get_symbol("GetModule");
+    else
+        std::cout << "GetModule symbol could not be found" << std::endl;
 
     dylib::native_handle_type handle = lib.native_handle();
     void *sym = dlsym(handle, "GetModule");
@@ -144,7 +149,7 @@ try {
     std::cout << pi_value << std::endl;
 }
 catch (const dylib::load_error &e) {
-    // failed loading "foo" lib
+    // failed loading "foo" library
 }
 catch (const dylib::symbol_error &e) {
     // failed loading "pi_value" symbol
@@ -166,4 +171,15 @@ cmake --build build
 To run unit tests, enter the following command inside "build" directory:
 ```sh
 ctest
+```
+
+# Community
+
+If you have any question about the usage of the library, do not hesitate to open a [discussion](https://github.com/martin-olivier/dylib/discussions)
+
+If you want to report a bug or provide a feature, do not hesitate to open an [issue](https://github.com/martin-olivier/dylib/issues) or submit a [pull request](https://github.com/martin-olivier/dylib/pulls)
+
+> Do not forget to sign your commits and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) when providing a pull request
+```sh
+git commit -s -m "feat: ..."
 ```

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -15,7 +15,7 @@ include(FetchContent)
 FetchContent_Declare(
     dylib
     GIT_REPOSITORY  "https://github.com/martin-olivier/dylib"
-    GIT_TAG         "v2.0.0"
+    GIT_TAG         "v2.1.0"
 )
 
 FetchContent_MakeAvailable(dylib)

--- a/example/README.md
+++ b/example/README.md
@@ -82,7 +82,7 @@ include(FetchContent)
 FetchContent_Declare(
     dylib
     GIT_REPOSITORY  "https://github.com/martin-olivier/dylib"
-    GIT_TAG         "v2.0.0"
+    GIT_TAG         "v2.1.0"
 )
 
 FetchContent_MakeAvailable(dylib)

--- a/include/dylib.hpp
+++ b/include/dylib.hpp
@@ -1,6 +1,6 @@
 /**
  * @file dylib.hpp
- * @version 2.0.0
+ * @version 2.1.0
  * @brief C++ cross-platform wrapper around dynamic loading of shared libraries
  * @link https://github.com/martin-olivier/dylib
  * 
@@ -51,8 +51,10 @@ public:
         static constexpr const char *suffix = DYLIB_WIN_MAC_OTHER(".dll", ".dylib", ".so");
     };
     using native_handle_type = DYLIB_WIN_OTHER(HINSTANCE, void *);
+    using native_symbol_type = DYLIB_WIN_OTHER(FARPROC, void *);
 
     static_assert(std::is_pointer<native_handle_type>::value, "Expecting HINSTANCE to be a pointer");
+    static_assert(std::is_pointer<native_symbol_type>::value, "Expecting FARPROC to be a pointer");
 
     static constexpr bool add_filename_decorations = true;
     static constexpr bool no_filename_decorations = false;
@@ -146,8 +148,8 @@ public:
         : dylib("", lib_name, decorations) {}
 
 #ifdef DYLIB_CPP17
-    explicit dylib(const std::filesystem::path &path)
-        : dylib("", path.string().c_str(), no_filename_decorations) {}
+    explicit dylib(const std::filesystem::path &lib_path)
+        : dylib("", lib_path.string().c_str(), no_filename_decorations) {}
 
     dylib(const std::filesystem::path &dir_path, const std::string &lib_name, bool decorations = add_filename_decorations)
         : dylib(dir_path.string().c_str(), lib_name.c_str(), decorations) {}
@@ -163,23 +165,49 @@ public:
     }
 
     /**
+     *  Get a symbol from the dynamic library currently loaded in the object
+     * 
+     *  @throws dylib::symbol_error if the symbol could not be found
+     *
+     *  @param symbol_name the symbol name to get from the dynamic library
+     *
+     *  @return a pointer to the requested symbol
+     */
+    native_symbol_type get_symbol(const char *symbol_name) const {
+        if (!symbol_name)
+            throw std::invalid_argument("Null parameter");
+        if (!m_handle)
+            throw std::logic_error("The dynamic library handle is null");
+
+        auto symbol = locate_symbol(m_handle, symbol_name);
+
+        if (symbol == nullptr)
+            throw symbol_error("Could not get symbol \"" + std::string(symbol_name) + "\"\n" + get_error_description());
+        return symbol;
+    }
+
+    native_symbol_type get_symbol(const std::string &symbol_name) const {
+        return get_symbol(symbol_name.c_str());
+    }
+
+    /**
      *  Get a function from the dynamic library currently loaded in the object
      * 
      *  @throws dylib::symbol_error if the symbol could not be found
      *
      *  @param T the template argument must be the function prototype to get
-     *  @param name the symbol name of a function to get from the dynamic library
+     *  @param symbol_name the symbol name of a function to get from the dynamic library
      *
      *  @return a pointer to the requested function
      */
     template<typename T>
-    T *get_function(const char *name) const {
-        return reinterpret_cast<T *>(locate_symbol(name));
+    T *get_function(const char *symbol_name) const {
+        return reinterpret_cast<T *>(get_symbol(symbol_name));
     }
 
     template<typename T>
-    T *get_function(const std::string &name) const {
-        return get_function<T>(name.c_str());
+    T *get_function(const std::string &symbol_name) const {
+        return get_function<T>(symbol_name.c_str());
     }
 
     /**
@@ -188,33 +216,33 @@ public:
      *  @throws dylib::symbol_error if the symbol could not be found
      *
      *  @param T the template argument must be the type of the variable to get
-     *  @param name the symbol name of a variable to get from the dynamic library
+     *  @param symbol_name the symbol name of a variable to get from the dynamic library
      *
      *  @return a reference to the requested variable
      */
     template<typename T>
-    T &get_variable(const char *name) const {
-        return *reinterpret_cast<T *>(locate_symbol(name));
+    T &get_variable(const char *symbol_name) const {
+        return *reinterpret_cast<T *>(get_symbol(symbol_name));
     }
 
     template<typename T>
-    T &get_variable(const std::string &name) const {
-        return get_variable<T>(name.c_str());
+    T &get_variable(const std::string &symbol_name) const {
+        return get_variable<T>(symbol_name.c_str());
     }
 
     /**
      *  Check if a symbol exists in the currently loaded dynamic library. 
      *  This method will return false if no dynamic library is currently loaded 
-     *  or if the symbol equals nullptr
+     *  or if the symbol name is nullptr
      *
-     *  @param symbol the symbol name to look for
+     *  @param symbol_name the symbol name to look for
      *
      *  @return true if the symbol exists in the dynamic library, false otherwise
      */
-    bool has_symbol(const char *symbol) const noexcept {
-        if (!m_handle || !symbol)
+    bool has_symbol(const char *symbol_name) const noexcept {
+        if (!m_handle || !symbol_name)
             return false;
-        return get_symbol(m_handle, symbol) != nullptr;
+        return locate_symbol(m_handle, symbol_name) != nullptr;
     }
 
     bool has_symbol(const std::string &symbol) const noexcept {
@@ -239,21 +267,7 @@ protected:
 #endif
     }
 
-    void *locate_symbol(const char *name) const {
-        if (!name)
-            throw std::invalid_argument("Null parameter");
-        if (!m_handle)
-            throw std::logic_error("The dynamic library handle is null");
-
-        auto symbol = get_symbol(m_handle, name);
-
-        if (symbol == nullptr)
-            throw symbol_error("Could not locate symbol \"" + std::string(name) + "\"\n" + get_error_description());
-        return symbol;
-    }
-
-    static DYLIB_WIN_OTHER(FARPROC, void *)
-    get_symbol(native_handle_type lib, const char *name) noexcept {
+    static native_symbol_type locate_symbol(native_handle_type lib, const char *name) noexcept {
         return DYLIB_WIN_OTHER(GetProcAddress, dlsym)(lib, name);
     }
 

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -185,6 +185,25 @@ TEST(system_lib, basic_test) {
 #endif
 }
 
+#if ((defined(_MSVC_LANG) && _MSVC_LANG >= 201703L) || __cplusplus >= 201703L)
+TEST(filesystem, basic_test) {
+    bool has_sym = dylib(std::filesystem::path("."), "dynamic_lib").has_symbol("pi_value");
+    EXPECT_TRUE(has_sym);
+
+    bool found = false;
+    for (const auto &file : std::filesystem::recursive_directory_iterator(".")) {
+        if (file.path().extension() == dylib::filename_components::suffix) {
+            try {
+                dylib lib(file.path());
+                if (lib.has_symbol("pi_value"))
+                    found = true;
+            } catch (const std::exception &) {}
+        }
+    }
+    EXPECT_TRUE(found);
+}
+#endif
+
 int main(int ac, char **av) {
     testing::InitGoogleTest(&ac, av);
     return RUN_ALL_TESTS();

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -126,7 +126,7 @@ TEST(invalid_argument, null_pointer) {
 }
 
 TEST(manual_decorations, basic_test) {
-    dylib lib(".", dylib::filename_components::prefix + std::string("dynamic_lib") + dylib::filename_components::suffix, false);
+    dylib lib(".", dylib::filename_components::prefix + std::string("dynamic_lib") + dylib::filename_components::suffix, dylib::no_filename_decorations);
     auto pi = lib.get_variable<double>("pi_value");
     EXPECT_EQ(pi, 3.14159);
 }


### PR DESCRIPTION
# Description

feat: `add_filename_decorations` and `no_filename_decorations` constants
feat: `get_symbol` public member function and `2.1.0` version setup
feat: CI now checks both `c++11` and `c++17`
fix: protected `dylib` members have been renamed
fix: timeout issues on windows CI
fix: cleaner documentation

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)