### PR TITLE
fix(mingw): fix build prefix of mingw shared libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,11 @@ if(UNIX)
     target_link_libraries(dylib INTERFACE dl)
 endif()
 
+if (WIN32 AND MINGW)
+    # MinGW adds a "lib" prefix to DLLs; this restores the default Windows behavior
+    set_target_properties(dylib PROPERTIES PREFIX "" IMPORT_PREFIX "")
+endif ()
+
 option(DYLIB_BUILD_TESTS "When set to ON, build unit tests" OFF)
 option(DYLIB_WARNING_AS_ERRORS "Treat warnings as errors" OFF)
 


### PR DESCRIPTION
Fixes #62

# Description

Fixed build with MinGW by changing shared library prefix back to Windows' default.

# Changes include

- [X] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [x] I have tested this code
- [x] I have added sufficient documentation in the code
