### PR TITLE
fix: mingw

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,14 +26,17 @@ jobs:
       matrix:
         os: [windows-latest, macos-latest, ubuntu-latest]
         cxx-std: [11, 14, 17, 20]
-        generator: [Ninja]
+        generator: [Unix Makefiles]
+        exclude:
+          - os: windows-latest
+            generator: Unix Makefiles
         include:
           - os: windows-latest
-            generator: [Visual Studio 17, MinGW Makefiles]
+            generator: Visual Studio 17
+          - os: windows-latest
+            generator: MinGW Makefiles
           - os: macos-latest
-            generator: [Unix Makefiles, Xcode]
-          - os: ubuntu-latest
-            generator: [Unix Makefiles]
+            generator: Xcode
 
     name: ${{ matrix.os }} (C++${{ matrix.cxx-std }} - ${{ matrix.generator }})
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,17 +26,18 @@ jobs:
       matrix:
         os: [windows-latest, macos-latest, ubuntu-latest]
         cxx-std: [11, 14, 17, 20]
-        generator: [Unix Makefiles]
+        generator: [Unix Makefiles, MinGW Makefiles, Visual Studio 17]
         exclude:
           - os: windows-latest
             generator: Unix Makefiles
-        include:
-          - os: windows-latest
-            generator: Visual Studio 17
-          - os: windows-latest
+          - os: macos-latest
             generator: MinGW Makefiles
           - os: macos-latest
-            generator: Xcode
+            generator: Visual Studio 17
+          - os: ubuntu-latest
+            generator: MinGW Makefiles
+          - os: ubuntu-latest
+            generator: Visual Studio 17
 
     name: ${{ matrix.os }} (C++${{ matrix.cxx-std }} - ${{ matrix.generator }})
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,11 +26,12 @@ jobs:
       matrix:
         os: [windows-latest, macos-latest, ubuntu-latest]
         cxx-std: [11, 14, 17, 20]
+        generator: [Ninja]
         include:
           - os: windows-latest
             generator: [Visual Studio 17, MinGW Makefiles]
           - os: macos-latest
-            generator: [Unix Makefiles]
+            generator: [Unix Makefiles, Xcode]
           - os: ubuntu-latest
             generator: [Unix Makefiles]
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,6 +1,19 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    paths:
+      - .github/workflows/CI.yml
+      - CMakeLists.txt
+      - include/*
+      - tests/*
+
+  pull_request:
+    paths:
+      - .github/workflows/CI.yml
+      - CMakeLists.txt
+      - include/*
+      - tests/*
 
 defaults:
   run:
@@ -12,16 +25,23 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, macos-latest, ubuntu-latest]
-        cxx-std: [11, 17]
+        cxx-std: [11, 14, 17, 20]
+        include:
+          - os: windows-latest
+            generator: [Visual Studio 17, MinGW Makefiles]
+          - os: macos-latest
+            generator: [Unix Makefiles]
+          - os: ubuntu-latest
+            generator: [Unix Makefiles]
 
-    name: ${{ matrix.os }} (C++${{ matrix.cxx-std }})
+    name: ${{ matrix.os }} (C++${{ matrix.cxx-std }} - ${{ matrix.generator }})
     runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v2
 
       - name: Generate project files
-        run: cmake . -B build -DCMAKE_CXX_STANDARD=${{ matrix.cxx-std }} -DDYLIB_BUILD_TESTS=ON -DDYLIB_WARNING_AS_ERRORS=ON
+        run: cmake . -B build -G "${{ matrix.generator }}" -DCMAKE_CXX_STANDARD=${{ matrix.cxx-std }} -DDYLIB_BUILD_TESTS=ON -DDYLIB_WARNING_AS_ERRORS=ON
 
       - name: Build dynamic library and unit tests
         run: cmake --build build
@@ -31,11 +51,11 @@ jobs:
         run: ctest
 
       - name: Generate code coverage
-        if: ${{ matrix.os == 'ubuntu-latest' && matrix.cxx-std == 17 }}
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.cxx-std == 20 }}
         run: gcov -abcfu build/CMakeFiles/unit_tests.dir/tests/tests.cpp.gcda
 
       - name: Send coverage to codecov.io
-        if: ${{ matrix.os == 'ubuntu-latest' && matrix.cxx-std == 17 }}
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.cxx-std == 20 }}
         uses: codecov/codecov-action@v2
         with:
           files: dylib.hpp.gcov
@@ -54,7 +74,7 @@ jobs:
         run: sudo apt install -y valgrind
 
       - name: Generate tests build file
-        run: cmake . -B build -DCMAKE_CXX_STANDARD=17 -DDYLIB_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Debug
+        run: cmake . -B build -DCMAKE_CXX_STANDARD=20 -DDYLIB_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Debug
 
       - name: Build unit tests
         run: cmake --build build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,28 +24,31 @@ if(DYLIB_BUILD_TESTS)
     include(FetchContent)
     FetchContent_Declare(
         googletest
-        URL https://github.com/google/googletest/archive/refs/tags/release-1.11.0.zip
+        URL https://github.com/google/googletest/archive/refs/tags/release-1.12.1.zip
     )
     set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
     FetchContent_MakeAvailable(googletest)
 
-    if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
         add_compile_options(-Wall -Wextra -Weffc++)
-    elseif (CMAKE_CXX_COMPILER_ID MATCHES ".*Clang")
+    elseif(CMAKE_CXX_COMPILER_ID MATCHES ".*Clang")
         add_compile_options(-Wall -Wextra)
-    elseif (MSVC)
+    elseif(MSVC)
         add_compile_options(/W4)
-    endif ()
+    endif()
 
-    if (DYLIB_WARNING_AS_ERRORS)
-        if (MSVC)
+    if(DYLIB_WARNING_AS_ERRORS)
+        if(MSVC)
             add_compile_options(/WX)
-        elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES ".*Clang")
+        elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES ".*Clang")
             add_compile_options(-Werror)
-        endif ()
-    endif ()
+        endif()
+    endif()
 
     add_library(dynamic_lib SHARED tests/lib.cpp)
+    if(WIN32 AND MINGW)
+        set_target_properties(dynamic_lib PROPERTIES PREFIX "")
+    endif()
 
     enable_testing()
 
@@ -54,7 +57,7 @@ if(DYLIB_BUILD_TESTS)
     endif()
 
     add_executable(unit_tests tests/tests.cpp)
-    add_dependencies(unit_tests dynamic_lib)  # Build dynamic_lib alongside unit tests
+    add_dependencies(unit_tests dynamic_lib)
     target_link_libraries(unit_tests PRIVATE gtest_main dylib)
 
     if(UNIX AND NOT APPLE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,5 +65,5 @@ if(DYLIB_BUILD_TESTS)
     endif()
 
     include(GoogleTest)
-    gtest_discover_tests(unit_tests PROPERTIES TIMEOUT 600 WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
+    gtest_discover_tests(unit_tests PROPERTIES DISCOVERY_TIMEOUT 600 WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
 endif()

--- a/README.md
+++ b/README.md
@@ -177,7 +177,9 @@ If you want to report a bug or provide a feature, do not hesitate to open an [is
 ## Contributing
 
 Set the cmake flag `DYLIB_BUILD_TESTS` to `ON` to enable tests and make it easier for you to contribute!  
-> `cmake -DDYLIB_BUILD_TESTS=ON <directory>`
+```sh
+cmake . -B build -DDYLIB_BUILD_TESTS=ON
+```
 
 > Do not forget to sign your commits and use [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) when providing a pull request
 ```sh

--- a/include/dylib.hpp
+++ b/include/dylib.hpp
@@ -21,7 +21,7 @@
 #include <filesystem>
 #endif
 
-#if defined(_WIN32) || defined(_WIN64)
+#if (defined(_WIN32) || defined(_WIN64))
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #undef WIN32_LEAN_AND_MEAN
@@ -29,7 +29,7 @@
 #include <dlfcn.h>
 #endif
 
-#if defined(_WIN32) || defined(_WIN64)
+#if (defined(_WIN32) || defined(_WIN64))
 #define DYLIB_WIN_MAC_OTHER(win_def, mac_def, other_def) win_def
 #define DYLIB_WIN_OTHER(win_def, other_def) win_def
 #elif defined(__APPLE__)
@@ -202,7 +202,14 @@ public:
      */
     template<typename T>
     T *get_function(const char *symbol_name) const {
+#if (defined(__GNUC__) && __GNUC__ >= 8)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-function-type"
+#endif
         return reinterpret_cast<T *>(get_symbol(symbol_name));
+#if (defined(__GNUC__) && __GNUC__ >= 8)
+#pragma GCC diagnostic pop
+#endif
     }
 
     template<typename T>
@@ -260,7 +267,7 @@ protected:
     native_handle_type m_handle{nullptr};
 
     static native_handle_type open(const char *path) noexcept {
-#if defined(_WIN32) || defined(_WIN64)
+#if (defined(_WIN32) || defined(_WIN64))
         return LoadLibraryA(path);
 #else
         return dlopen(path, RTLD_NOW | RTLD_LOCAL);
@@ -276,7 +283,7 @@ protected:
     }
 
     static std::string get_error_description() noexcept {
-#if defined(_WIN32) || defined(_WIN64)
+#if (defined(_WIN32) || defined(_WIN64))
         constexpr const size_t buf_size = 512;
         auto error_code = GetLastError();
         if (!error_code)


### PR DESCRIPTION
Signed-off-by: Martin Olivier <martin.olivier@live.fr>
Fixes https://github.com/martin-olivier/dylib/issues/62

# Description

Fixed build with MinGW by changing shared library prefix back to Windows' default.
Added MinGW build and tests in the CI

# Changes include

- [X] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [X] I have assigned this PR to myself
- [X] I have added at least 1 reviewer
- [X] I have tested this code
- [X] I have added sufficient documentation in the code