### PR TITLE
Allow disabling use of <filesystem> on C++17

### DIFF
--- a/include/dylib.hpp
+++ b/include/dylib.hpp
@@ -16,7 +16,7 @@
 #include <stdexcept>
 #include <utility>
 
-#if ((defined(_MSVC_LANG) && _MSVC_LANG >= 201703L) || __cplusplus >= 201703L)
+#if (!defined(DYLIB_NO_FILESYSTEM) && ((defined(_MSVC_LANG) && _MSVC_LANG >= 201703L) || __cplusplus >= 201703L))
 #define DYLIB_CPP17
 #include <filesystem>
 #endif

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -166,7 +166,7 @@ TEST(system_lib, basic_test) {
 #endif
 }
 
-#if ((defined(_MSVC_LANG) && _MSVC_LANG >= 201703L) || __cplusplus >= 201703L)
+#if (defined(DYLIB_CPP17))
 TEST(filesystem, basic_test) {
     bool has_sym = dylib(std::filesystem::path("."), "dynamic_lib").has_symbol("pi_value");
     EXPECT_TRUE(has_sym);


### PR DESCRIPTION
# Description

Please provide a detailed description of what was done in this PR.

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [x] I have assigned this PR to myself
- [x] I have added at least 1 reviewer
- [x] I have tested this code
- [x] I have added sufficient documentation in the code

# Additional comments

`<filesystem>` is quite a big header. On my system `echo '#include <filesystem>' | c++ -E -x c++ - | wc -l` shows that it is 50K lines of code. Including such a large header unnecessarily in projects with a lot of translation units can affect build times quite significantly. Therefore, I added an escape hatch that allows such projects to opt-out of `std::filesystem` support if they don't need it.