### PR TITLE
Remove warning C4005 - prevent 'WIN32_LEAN_AND_MEAN' macro redefinition if it is already defined in the parent project.

### DIFF
--- a/include/dylib.hpp
+++ b/include/dylib.hpp
@@ -22,9 +22,13 @@
 #endif
 
 #if (defined(_WIN32) || defined(_WIN64))
+#ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #undef WIN32_LEAN_AND_MEAN
+#else
+#include <windows.h>
+#endif
 #else
 #include <dlfcn.h>
 #endif

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -160,9 +160,6 @@ TEST(system_lib, basic_test) {
 #elif defined(__APPLE__)
     dylib lib("ssh2");
     lib.get_function<const char *(int)>("libssh2_version");
-#else
-    dylib lib("pthread");
-    lib.get_function<int()>("pthread_yield");
 #endif
 }
 


### PR DESCRIPTION
Remove warning C4005 - prevent 'WIN32_LEAN_AND_MEAN' macro redefinition if it is already defined in the parent project.