### PR TITLE
Fix and enhance the error messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,18 +1,50 @@
 # Editor files and folders
-
 .idea/
+.vs/
 .vscode/
-.DS_Store
+.DS_Store/
 *~
 \#*#
 
 # Build Folders
-
-cmake-build-*
-build
+cmake-build-*/
+build/
+out/
 
 # Coverage files
-
 *.gcda
 *.gcno
 *.gcov
+
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app

--- a/include/dylib.hpp
+++ b/include/dylib.hpp
@@ -285,14 +285,14 @@ protected:
 
     static std::string get_error_description() noexcept {
 #if (defined(_WIN32) || defined(_WIN64))
-        constexpr const size_t buf_size = 512;
+        constexpr const size_t BUF_SIZE = 512;
         const auto error_code = GetLastError();
         if (!error_code)
             return "No error reported by GetLastError";
-        char description[buf_size];
+        char description[BUF_SIZE];
         const auto lang = MAKELANGID(LANG_ENGLISH, SUBLANG_ENGLISH_US);
         const DWORD length =
-            FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM, nullptr, error_code, lang, description, buf_size, nullptr);
+            FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM, nullptr, error_code, lang, description, BUF_SIZE, nullptr);
         return (length == 0) ? "Unknown error (FormatMessage failed)" : description;
 #else
         const auto description = dlerror();

--- a/include/dylib.hpp
+++ b/include/dylib.hpp
@@ -282,7 +282,7 @@ protected:
         constexpr const size_t buf_size = 512;
         auto error_code = GetLastError();
         if (!error_code)
-            return "Unknown error (GetLastError failed)";
+            return "No error reported by GetLastError";
         char description[512];
         auto lang = MAKELANGID(LANG_ENGLISH, SUBLANG_ENGLISH_US);
         const DWORD length =
@@ -290,7 +290,7 @@ protected:
         return (length == 0) ? "Unknown error (FormatMessage failed)" : description;
 #else
         auto description = dlerror();
-        return (description == nullptr) ? "Unknown error (dlerror failed)" : description;
+        return (description == nullptr) ? "No error reported by dlerror" : description;
 #endif
     }
 };

--- a/include/dylib.hpp
+++ b/include/dylib.hpp
@@ -280,16 +280,16 @@ protected:
     static std::string get_error_description() noexcept {
 #if (defined(_WIN32) || defined(_WIN64))
         constexpr const size_t buf_size = 512;
-        auto error_code = GetLastError();
+        const auto error_code = GetLastError();
         if (!error_code)
             return "No error reported by GetLastError";
-        char description[512];
-        auto lang = MAKELANGID(LANG_ENGLISH, SUBLANG_ENGLISH_US);
+        char description[buf_size];
+        const auto lang = MAKELANGID(LANG_ENGLISH, SUBLANG_ENGLISH_US);
         const DWORD length =
             FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM, nullptr, error_code, lang, description, buf_size, nullptr);
         return (length == 0) ? "Unknown error (FormatMessage failed)" : description;
 #else
-        auto description = dlerror();
+        const auto description = dlerror();
         return (description == nullptr) ? "No error reported by dlerror" : description;
 #endif
     }

--- a/include/dylib.hpp
+++ b/include/dylib.hpp
@@ -65,32 +65,23 @@ public:
 
     /**
      *  This exception is raised when the library failed to load a dynamic library or a symbol
-     *
-     *  @param message the error message
      */
     class exception : public std::runtime_error {
-    public:
-        explicit exception(const std::string &message) : std::runtime_error(message) {}
+        using std::runtime_error::runtime_error;
     };
 
     /**
      *  This exception is raised when the library failed to load or encountered symbol resolution issues
-     *
-     *  @param message the error message
      */
     class load_error : public exception {
-    public:
-        explicit load_error(const std::string &message) : exception(message) {}
+        using exception::exception;
     };
 
     /**
      *  This exception is raised when the library failed to load a symbol
-     *
-     *  @param message the error message
      */
     class symbol_error : public exception {
-    public:
-        explicit symbol_error(const std::string &message) : exception(message) {}
+        using exception::exception;
     };
 
     dylib(const dylib&) = delete;

--- a/include/dylib.hpp
+++ b/include/dylib.hpp
@@ -45,8 +45,8 @@
 #endif
 
 /**
- *  The dylib class can hold a dynamic library instance and interact with it 
- *  by getting its symbols like functions or global variables
+ *  The `dylib` class represents a single dynamic library instance,
+ *  allowing the access of symbols like functions or global variables
  */
 class dylib {
 public:
@@ -64,21 +64,21 @@ public:
     static constexpr bool no_filename_decorations = false;
 
     /**
-     *  This exception is raised when the library failed to load a dynamic library or a symbol
+     *  This exception is raised when a library fails to load or a symbol fails to resolve
      */
     class exception : public std::runtime_error {
         using std::runtime_error::runtime_error;
     };
 
     /**
-     *  This exception is raised when the library failed to load or encountered symbol resolution issues
+     *  This exception is raised when a library fails to load
      */
     class load_error : public exception {
         using exception::exception;
     };
 
     /**
-     *  This exception is raised when the library failed to load a symbol
+     *  This exception is raised when a symbol fails to resolve
      */
     class symbol_error : public exception {
         using exception::exception;
@@ -98,14 +98,15 @@ public:
     }
 
     /**
-     *  @brief Loads a dynamic library
+     *  Loads a dynamic library
      *
-     *  @throws dylib::load_error if the library could not be opened (including
+     *  @throws `dylib::load_error` if the library could not be opened (including
      *  the case of the library file not being found)
+     *  @throws `std::invalid_argument` if the arguments are null
      *
-     *  @param dir_path the directory path where is located the dynamic library you want to load
+     *  @param dir_path the directory path where the dynamic library is located
      *  @param name the name of the dynamic library to load
-     *  @param decorations add os decorations to the library name
+     *  @param decorations adds OS-specific decorations to the library name
      */
     ///@{
     dylib(const char *dir_path, const char *lib_name, bool decorations = add_filename_decorations) {
@@ -162,11 +163,12 @@ public:
     }
 
     /**
-     *  Get a symbol from the dynamic library currently loaded in the object
+     *  Get a symbol from the currently loaded dynamic library
      * 
-     *  @throws dylib::symbol_error if the symbol could not be found
+     *  @throws `dylib::symbol_error` if the symbol could not be found
+     *  @throws `std::invalid_argument` if the argument or library handle is null
      *
-     *  @param symbol_name the symbol name to get from the dynamic library
+     *  @param symbol_name the symbol name to lookup
      *
      *  @return a pointer to the requested symbol
      */
@@ -188,12 +190,13 @@ public:
     }
 
     /**
-     *  Get a function from the dynamic library currently loaded in the object
+     *  Get a function from the currently loaded dynamic library
      * 
-     *  @throws dylib::symbol_error if the symbol could not be found
+     *  @throws `dylib::symbol_error` if the function could not be found
+     *  @throws `std::invalid_argument` if the argument is null
      *
-     *  @param T the template argument must be the function prototype to get
-     *  @param symbol_name the symbol name of a function to get from the dynamic library
+     *  @tparam T the function type, e.g., `double(int, int)`
+     *  @param symbol_name the function name to lookup
      *
      *  @return a pointer to the requested function
      */
@@ -215,12 +218,13 @@ public:
     }
 
     /**
-     *  Get a variable from the dynamic library currently loaded in the object
+     *  Get a variable from the currently loaded dynamic library
      * 
-     *  @throws dylib::symbol_error if the symbol could not be found
+     *  @throws `dylib::symbol_error` if the variable could not be found
+     *  @throws `std::invalid_argument` if the argument is null
      *
-     *  @param T the template argument must be the type of the variable to get
-     *  @param symbol_name the symbol name of a variable to get from the dynamic library
+     *  @tparam T the variable type
+     *  @param symbol_name the variable name to lookup
      *
      *  @return a reference to the requested variable
      */

--- a/include/dylib.hpp
+++ b/include/dylib.hpp
@@ -109,8 +109,10 @@ public:
      */
     ///@{
     dylib(const char *dir_path, const char *lib_name, bool decorations = add_filename_decorations) {
-        if (!dir_path || !lib_name)
-            throw std::invalid_argument("Null parameter");
+        if (!dir_path)
+            throw std::invalid_argument("The directory path is null");
+        if (!lib_name)
+            throw std::invalid_argument("The library name is null");
 
         std::string final_name = lib_name;
         std::string final_path = dir_path;
@@ -170,9 +172,9 @@ public:
      */
     native_symbol_type get_symbol(const char *symbol_name) const {
         if (!symbol_name)
-            throw std::invalid_argument("Null parameter");
+            throw std::invalid_argument("The symbol name to lookup is null");
         if (!m_handle)
-            throw std::logic_error("The dynamic library handle is null");
+            throw std::logic_error("The dynamic library handle is null. This object may have been moved from.");
 
         auto symbol = locate_symbol(m_handle, symbol_name);
 

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -21,13 +21,9 @@ TEST(example, example_test) {
 }
 
 TEST(ctor, bad_library) {
-    try {
+    EXPECT_THROW({
         dylib lib("./", "no_such_library");
-        EXPECT_EQ(true, false);
-    }
-    catch (const dylib::load_error &) {
-        EXPECT_EQ(true, true);
-    }
+    }, dylib::load_error);
 }
 
 TEST(multiple_handles, basic_test) {
@@ -36,25 +32,17 @@ TEST(multiple_handles, basic_test) {
 }
 
 TEST(get_function, bad_symbol) {
-    try {
+    EXPECT_THROW({
         dylib lib("./", "dynamic_lib");
         lib.get_function<double(double, double)>("unknown");
-        EXPECT_EQ(true, false);
-    }
-    catch (const dylib::symbol_error &) {
-        EXPECT_EQ(true, true);
-    }
+    }, dylib::symbol_error);
 }
 
 TEST(get_variable, bad_symbol) {
-    try {
+    EXPECT_THROW({
         dylib lib("./", "dynamic_lib");
         lib.get_variable<double>("unknown");
-        EXPECT_EQ(true, false);
-    }
-    catch (const dylib::symbol_error &) {
-        EXPECT_EQ(true, true);
-    }
+    }, dylib::symbol_error);
 }
 
 TEST(get_variable, alter_variables) {
@@ -74,29 +62,23 @@ TEST(get_variable, alter_variables) {
 }
 
 TEST(invalid_argument, null_pointer) {
-    try {
+    EXPECT_THROW({
         dylib(nullptr);
-        EXPECT_EQ(true, false);
-    }
-    catch (const std::invalid_argument &) {
-        EXPECT_EQ(true, true);
-    }
-    try {
+    }, std::invalid_argument);
+
+    EXPECT_THROW({
+        dylib(nullptr, "dynamic_lib");
+    }, std::invalid_argument);
+
+    EXPECT_THROW({
         dylib lib("./", "dynamic_lib");
         lib.get_function<void()>(nullptr);
-        EXPECT_EQ(true, false);
-    }
-    catch (const std::invalid_argument &) {
-        EXPECT_EQ(true, true);
-    }
-    try {
+    }, std::invalid_argument);
+
+    EXPECT_THROW({
         dylib lib("./", "dynamic_lib");
         lib.get_variable<void *>(nullptr);
-        EXPECT_EQ(true, false);
-    }
-    catch (const std::invalid_argument &) {
-        EXPECT_EQ(true, true);
-    }
+    }, std::invalid_argument);
 }
 
 TEST(manual_decorations, basic_test) {
@@ -106,7 +88,7 @@ TEST(manual_decorations, basic_test) {
 }
 
 TEST(std_move, basic_test) {
-    try {
+    EXPECT_THROW({
         dylib lib("./", "dynamic_lib");
         dylib other(std::move(lib));
         auto pi = other.get_variable<double>("pi_value");
@@ -115,11 +97,7 @@ TEST(std_move, basic_test) {
         auto ptr = lib.get_variable<void *>("ptr");
         EXPECT_EQ(ptr, (void *)1);
         other.get_variable<double>("pi_value");
-        EXPECT_EQ(true, false);
-    }
-    catch (const std::logic_error &) {
-        EXPECT_EQ(true, true);
-    }
+    }, std::logic_error);
 }
 
 TEST(has_symbol, basic_test) {


### PR DESCRIPTION
# Description

Improve the error messages along with some minor changes. 😊
- Update comments for clarity
- Add more information in the error messages
- Modify error messages for cases where the last error code is a success code
  - `GetLastError` returning 0 and `dlerror` returning null means that the previous operation was successful, not that the functions failed. This could happen if another API call resets the error code before it is checked.
  - References:
    - [The Open Group - dlerror()](https://pubs.opengroup.org/onlinepubs/9699919799/functions/dlerror.html)
    - [Microsoft Documentation - GetLastError()](https://learn.microsoft.com/en-us/windows/win32/api/errhandlingapi/nf-errhandlingapi-getlasterror)
    - [Microsoft Documentation - System Error Codes (0-499)](https://learn.microsoft.com/en-us/windows/win32/debug/system-error-codes--0-499-)

# Changes include

- [ ] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [x] I have tested this code
- [x] I have added sufficient documentation in the code