### PR TITLE
Define NOMINMAX when including Windows.h

### DIFF
--- a/include/dylib.hpp
+++ b/include/dylib.hpp
@@ -26,24 +26,19 @@
 #define WIN32_LEAN_AND_MEAN
 #define DYLIB_UNDEFINE_LEAN_AND_MEAN
 #endif
-
 #ifndef NOMINMAX
 #define NOMINMAX
 #define DYLIB_UNDEFINE_NOMINMAX
 #endif
-
 #include <windows.h>
-
 #ifdef DYLIB_UNDEFINE_LEAN_AND_MEAN
 #undef WIN32_LEAN_AND_MEAN
 #undef DYLIB_UNDEFINE_LEAN_AND_MEAN
 #endif
-
 #ifdef DYLIB_UNDEFINE_NOMINMAX
 #undef NOMINMAX
 #undef DYLIB_UNDEFINE_NOMINMAX
 #endif
-
 #else
 #include <dlfcn.h>
 #endif

--- a/include/dylib.hpp
+++ b/include/dylib.hpp
@@ -24,11 +24,26 @@
 #if (defined(_WIN32) || defined(_WIN64))
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
-#include <windows.h>
-#undef WIN32_LEAN_AND_MEAN
-#else
-#include <windows.h>
+#define DYLIB_UNDEFINE_LEAN_AND_MEAN
 #endif
+
+#ifndef NOMINMAX
+#define NOMINMAX
+#define DYLIB_UNDEFINE_NOMINMAX
+#endif
+
+#include <windows.h>
+
+#ifdef DYLIB_UNDEFINE_LEAN_AND_MEAN
+#undef WIN32_LEAN_AND_MEAN
+#undef DYLIB_UNDEFINE_LEAN_AND_MEAN
+#endif
+
+#ifdef DYLIB_UNDEFINE_NOMINMAX
+#undef NOMINMAX
+#undef DYLIB_UNDEFINE_NOMINMAX
+#endif
+
 #else
 #include <dlfcn.h>
 #endif


### PR DESCRIPTION
# Description
Hi, really nice library. I've recently got into an issue while using this library with `std::numeric_limits<T>::min()` and `std::numeric_limits<T>::max()` and it turned out those pesky evil `min` and `max` macros from `Windows.h` were the issue. This is a small pr that fixes it.

# Changes include

- [X] Bugfix (non-breaking change that solves an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (change that is not backwards-compatible and/or changes current functionality)

# Checklist

- [ ] I have assigned this PR to myself
- [ ] I have added at least 1 reviewer
- [X] I have tested this code
- [x] I have added sufficient documentation in the code