### PR TITLE
Added option to build as shared object

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,15 @@ set(SOURCES
     src/format.cpp
 )
 
-add_library(dylib STATIC ${SOURCES})
+if(DYLIB_SHARED)
+    add_library(dylib SHARED ${SOURCES})
+    if(WIN32)
+        set_target_properties(dylib PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
+    endif()
+else()
+    add_library(dylib STATIC ${SOURCES})
+endif()
+
 
 target_include_directories(dylib
     PUBLIC
@@ -71,6 +79,7 @@ install(
 
 option(DYLIB_BUILD_TESTS "When set to ON, build unit tests" OFF)
 option(DYLIB_WARNING_AS_ERRORS "Treat warnings as errors" OFF)
+option(DYLIB_SHARED "Build as shared object" ON)
 
 if(DYLIB_BUILD_TESTS)
     set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR})
@@ -123,3 +132,5 @@ if(DYLIB_BUILD_TESTS)
     include(GoogleTest)
     gtest_discover_tests(unit_tests PROPERTIES DISCOVERY_TIMEOUT 600 WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
 endif()
+
+


### PR DESCRIPTION
Hi.
I shall use dylib in a project of mine. Usually I allow change to build shared or static library. I added such option in CMake project file. 

Thanks for your nice job. 