### PR TITLE
refactor: modernize CMake build system and improve portability

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.11...3.31)
 
 project(dylib VERSION 3.0.1 LANGUAGES CXX)
 
+include(GNUInstallDirs)
+
 add_library(dylib)
 
 target_sources(dylib PRIVATE
@@ -18,14 +20,12 @@ endif()
 target_include_directories(dylib
     PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-        $<INSTALL_INTERFACE:include>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
 target_compile_features(dylib PUBLIC cxx_std_11)
 
 target_link_libraries(dylib PRIVATE ${CMAKE_DL_LIBS})
-
-include(GNUInstallDirs)
 
 install(
     TARGETS dylib

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,9 +26,7 @@ target_include_directories(dylib
         $<INSTALL_INTERFACE:include>
 )
 
-if(UNIX)
-    target_link_libraries(dylib PRIVATE dl)
-endif()
+target_link_libraries(dylib PRIVATE ${CMAKE_DL_LIBS})
 
 include(GNUInstallDirs)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,10 +13,6 @@ target_sources(dylib PRIVATE
     src/format.cpp
 )
 
-if(BUILD_SHARED_LIBS AND WIN32)
-    set_target_properties(dylib PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
-endif()
-
 target_include_directories(dylib
     PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
@@ -26,6 +22,10 @@ target_include_directories(dylib
 target_compile_features(dylib PUBLIC cxx_std_11)
 
 target_link_libraries(dylib PRIVATE ${CMAKE_DL_LIBS})
+
+if(BUILD_SHARED_LIBS AND WIN32)
+    set_target_properties(dylib PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
+endif()
 
 install(
     TARGETS dylib

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,14 +2,14 @@ cmake_minimum_required(VERSION 3.11...3.31)
 
 project(dylib VERSION 3.0.1 LANGUAGES CXX)
 
-set(SOURCES
+add_library(dylib)
+
+target_sources(dylib PRIVATE
     src/dylib.cpp
     src/symbols.cpp
     src/demangle.cpp
     src/format.cpp
 )
-
-add_library(dylib ${SOURCES})
 
 if(BUILD_SHARED_LIBS AND WIN32)
     set_target_properties(dylib PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,11 +2,6 @@ cmake_minimum_required(VERSION 3.11...3.31)
 
 project(dylib VERSION 3.0.1 LANGUAGES CXX)
 
-if(NOT "${CMAKE_CXX_STANDARD}")
-    set(CMAKE_CXX_STANDARD 11)
-endif()
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
 set(SOURCES
     src/dylib.cpp
     src/symbols.cpp
@@ -25,6 +20,8 @@ target_include_directories(dylib
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         $<INSTALL_INTERFACE:include>
 )
+
+target_compile_features(dylib PUBLIC cxx_std_11)
 
 target_link_libraries(dylib PRIVATE ${CMAKE_DL_LIBS})
 


### PR DESCRIPTION
## Overview
This PR modernizes the CMake build system for the dylib project, improving maintainability, portability, and adherence to modern CMake best practices while remaining compatible with CMake 3.11.

### Changes
1. Modernized C++ standard handling
 - Replaced global `CMAKE_CXX_STANDARD` configuration
 - Enforced C++11 using target-based approach:
```cmake
target_compile_features(dylib PUBLIC cxx_std_11)
```

2. Migrated source definition to target-based model
 - Replaced `set(SOURCES)` + `add_library(... ${SOURCES})`
 - Adopted `target_sources()` for better modularity

3. Improved platform portability for dynamic linking
 - Replaced direct dl linkage with CMake-provided variable:
 ```cmake
target_link_libraries(dylib PRIVATE ${CMAKE_DL_LIBS})
 ```

### Summary
This refactor aligns the project with modern CMake practices while maintaining strict compatibility with CMake 3.11 and preserving existing behavior.