### PR TITLE
fix: symbols / sections followups

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -8,6 +8,7 @@ on:
       - include/*
       - tests/*
       - src/*
+      - example/*
 
   pull_request:
     paths:
@@ -16,6 +17,7 @@ on:
       - include/*
       - tests/*
       - src/*
+      - example/*
 
 defaults:
   run:
@@ -37,6 +39,37 @@ jobs:
 
       - name: Check formatting
         run: find src include tests -name '*.cpp' -o -name '*.hpp' | xargs clang-format --dry-run --Werror
+
+  example:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    name: example / ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # FETCHCONTENT_SOURCE_DIR_DYLIB makes FetchContent use the checked out
+      # sources instead of the released tag, so that the example is built
+      # against the code of the current branch.
+      - name: Generate project files
+        run: cmake example -B example/build -DFETCHCONTENT_SOURCE_DIR_DYLIB="${{ github.workspace }}"
+
+      - name: Build example
+        run: cmake --build example/build --config Release
+
+      # Multi config generators place the binaries in a per config subdirectory,
+      # and the example loads its dynamic library from the working directory.
+      - name: Run example
+        working-directory: example/build
+        run: |
+          if [ -d Release ]; then
+            cd Release
+          fi
+          ./dylib_example
 
   windows_msvc:
     strategy:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,18 @@
 cmake_minimum_required(VERSION 3.11...3.31)
 
-project(dylib VERSION 3.0.1 LANGUAGES CXX)
+file(READ "${CMAKE_CURRENT_SOURCE_DIR}/include/dylib.hpp" DYLIB_HEADER)
+
+foreach(part MAJOR MINOR PATCH)
+    if(NOT DYLIB_HEADER MATCHES "#define DYLIB_VERSION_${part} ([0-9]+)")
+        message(FATAL_ERROR "Could not parse DYLIB_VERSION_${part} from include/dylib.hpp")
+    endif()
+    set(DYLIB_VERSION_${part} ${CMAKE_MATCH_1})
+endforeach()
+
+project(dylib
+    VERSION ${DYLIB_VERSION_MAJOR}.${DYLIB_VERSION_MINOR}.${DYLIB_VERSION_PATCH}
+    LANGUAGES CXX
+)
 
 include(GNUInstallDirs)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dylib
 
-[![version](https://img.shields.io/badge/Version-3.0.1-blue.svg)](https://github.com/martin-olivier/dylib/releases/tag/v3.0.1)
+[![version](https://img.shields.io/badge/Version-3.1.0-blue.svg)](https://github.com/martin-olivier/dylib/releases/tag/v3.1.0)
 [![license](https://img.shields.io/badge/License-MIT-orange.svg)](https://github.com/martin-olivier/dylib/blob/main/LICENSE)
 [![cpp](https://img.shields.io/badge/Compatibility-C++11-darkgreen.svg)](https://isocpp.org)
 [![ci](https://github.com/martin-olivier/dylib/actions/workflows/CI.yml/badge.svg)](https://github.com/martin-olivier/dylib/actions/workflows/CI.yml)
@@ -28,7 +28,7 @@ vcpkg install dylib
 ```
 
 ```sh
-conan install --requires=dylib/3.0.1
+conan install --requires=dylib/3.1.0
 ```
 
 ### Using CMake Fetch
@@ -41,7 +41,7 @@ include(FetchContent)
 FetchContent_Declare(
     dylib
     GIT_REPOSITORY "https://github.com/martin-olivier/dylib"
-    GIT_TAG        "v3.0.1"
+    GIT_TAG        "v3.1.0"
 )
 
 FetchContent_MakeAvailable(dylib)
@@ -217,6 +217,17 @@ try {
 } catch (const dylib::symbol_error &) {
     std::cerr << "failed to get 'pi_value' symbol" << std::endl;
 }
+```
+
+### Version
+
+`dylib.hpp` exposes its version as macros, which lets you detect the availability of a feature at compile time:
+
+```c++
+#if DYLIB_VERSION_MAJOR > 3 || (DYLIB_VERSION_MAJOR == 3 && DYLIB_VERSION_MINOR >= 1)
+    for (auto &section : lib.sections())
+        std::cout << section << std::endl;
+#endif
 ```
 
 ## Example

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -15,7 +15,7 @@ include(FetchContent)
 FetchContent_Declare(
     dylib
     GIT_REPOSITORY  "https://github.com/martin-olivier/dylib"
-    GIT_TAG         "v3.0.1"
+    GIT_TAG         "v3.1.0"
 )
 
 FetchContent_MakeAvailable(dylib)

--- a/example/README.md
+++ b/example/README.md
@@ -34,7 +34,7 @@ You will have the following result:
 
 ```sh
 Hello World!
-dylib - v3.0.1
+dylib - v3.1.0
 pi value: 3.14159
 magic value: cafebabe
 10 + 10 = 20

--- a/example/lib.cpp
+++ b/example/lib.cpp
@@ -26,7 +26,7 @@ namespace example {
 
     namespace dylib {
         LIB_EXPORT std::string info() {
-            return "dylib - v3.0.1";
+            return "dylib - v3.1.0";
         }
     }
 

--- a/include/dylib.hpp
+++ b/include/dylib.hpp
@@ -325,7 +325,7 @@ public:
 protected:
     native_handle_type m_handle{nullptr};
 #ifndef _WIN32
-    int m_fd{-1};
+    std::string m_path;
 #endif
 };
 

--- a/include/dylib.hpp
+++ b/include/dylib.hpp
@@ -1,6 +1,6 @@
 /**
  * @file dylib.hpp
- * @version 3.0.1
+ * @version 3.1.0
  * @brief C++ cross-platform wrapper around dynamic loading of shared libraries
  * @link https://github.com/martin-olivier/dylib
  *
@@ -11,6 +11,21 @@
  */
 
 #pragma once
+
+#define DYLIB_VERSION_MAJOR 3
+#define DYLIB_VERSION_MINOR 1
+#define DYLIB_VERSION_PATCH 0
+
+#ifdef _WIN32
+#define DYLIB_WIN_MAC_OTHER(win_def, mac_def, other_def) win_def
+#define DYLIB_WIN_OTHER(win_def, other_def) win_def
+#elif defined(__APPLE__)
+#define DYLIB_WIN_MAC_OTHER(win_def, mac_def, other_def) mac_def
+#define DYLIB_WIN_OTHER(win_def, other_def) other_def
+#else
+#define DYLIB_WIN_MAC_OTHER(win_def, mac_def, other_def) other_def
+#define DYLIB_WIN_OTHER(win_def, other_def) other_def
+#endif
 
 #include <cstdint>
 #include <stdexcept>
@@ -40,17 +55,6 @@
 #undef NOMINMAX
 #undef DYLIB_UNDEFINE_NOMINMAX
 #endif
-#endif
-
-#ifdef _WIN32
-#define DYLIB_WIN_MAC_OTHER(win_def, mac_def, other_def) win_def
-#define DYLIB_WIN_OTHER(win_def, other_def) win_def
-#elif defined(__APPLE__)
-#define DYLIB_WIN_MAC_OTHER(win_def, mac_def, other_def) mac_def
-#define DYLIB_WIN_OTHER(win_def, other_def) other_def
-#else
-#define DYLIB_WIN_MAC_OTHER(win_def, mac_def, other_def) other_def
-#define DYLIB_WIN_OTHER(win_def, other_def) other_def
 #endif
 
 namespace dylib {

--- a/include/dylib.hpp
+++ b/include/dylib.hpp
@@ -320,7 +320,7 @@ public:
     /**
      *  @return the dynamic library handle
      */
-    native_handle_type native_handle() noexcept;
+    native_handle_type native_handle() const noexcept;
 
 protected:
     native_handle_type m_handle{nullptr};

--- a/src/dylib.cpp
+++ b/src/dylib.cpp
@@ -218,7 +218,7 @@ native_symbol_type library::get_symbol(const std::string &symbol_name) const {
     return get_symbol(symbol_name.c_str());
 }
 
-native_handle_type library::native_handle() noexcept {
+native_handle_type library::native_handle() const noexcept {
     return m_handle;
 }
 

--- a/src/dylib.cpp
+++ b/src/dylib.cpp
@@ -42,7 +42,6 @@ struct internal_symbol_info {
 
 std::vector<internal_symbol_info> get_symbols(native_handle_type handle, int fd);
 std::vector<std::string> get_sections(native_handle_type handle, int fd);
-std::string demangle_symbol(const char *symbol);
 
 static native_handle_type open_lib(const char *path) noexcept {
 #ifdef _WIN32
@@ -186,10 +185,14 @@ native_symbol_type library::get_symbol(const char *symbol_name) const {
     initial_error = get_error_description();
 
     for (const auto &sym : symbols()) {
-        if (!sym.loadable)
+        /*
+         * Only C++ symbols are considered here: a C symbol is not mangled, so it would
+         * already have been resolved by the locate_symbol call above.
+         */
+        if (!sym.loadable || sym.type != symbol_type::CPP)
             continue;
 
-        std::string demangled = demangle_symbol(sym.name.c_str());
+        const std::string &demangled = sym.demangled_name;
 
         if (demangled.find(symbol_name) == 0 &&
             (demangled.size() == symbol_name_len || demangled[symbol_name_len] == '('))

--- a/src/dylib.cpp
+++ b/src/dylib.cpp
@@ -89,10 +89,34 @@ static std::string get_error_description() noexcept {
 #endif
 }
 
+#ifndef _WIN32
+class scoped_fd {
+public:
+    explicit scoped_fd(const std::string &path) : m_fd(open(path.c_str(), O_RDONLY)) {
+        if (m_fd < 0)
+            throw std::runtime_error("Could not open file '" + path + "': " + strerror(errno));
+    }
+
+    scoped_fd(const scoped_fd &) = delete;
+    scoped_fd &operator=(const scoped_fd &) = delete;
+
+    ~scoped_fd() {
+        close(m_fd);
+    }
+
+    int get() const noexcept {
+        return m_fd;
+    }
+
+private:
+    int m_fd;
+};
+#endif
+
 library::library(library &&other) noexcept {
     std::swap(m_handle, other.m_handle);
 #ifndef _WIN32
-    std::swap(m_fd, other.m_fd);
+    std::swap(m_path, other.m_path);
 #endif
 }
 
@@ -100,7 +124,7 @@ library &library::operator=(library &&other) noexcept {
     if (this != &other) {
         std::swap(m_handle, other.m_handle);
 #ifndef _WIN32
-        std::swap(m_fd, other.m_fd);
+        std::swap(m_path, other.m_path);
 #endif
     }
     return *this;
@@ -140,9 +164,7 @@ library::library(const char *lib_path, dylib::decorations decorations) {
         throw load_error("Could not load library '" + lib + "':\n" + get_error_description());
 
 #ifndef _WIN32
-    m_fd = open(lib.c_str(), O_RDONLY);
-    if (m_fd < 0)
-        throw load_error("Could not open file '" + lib + "':\n" + strerror(errno));
+    m_path = lib;
 #endif
 }
 
@@ -157,10 +179,6 @@ library::library(const std::filesystem::path &lib_path, decorations decorations)
 library::~library() {
     if (m_handle)
         close_lib(m_handle);
-#ifndef _WIN32
-    if (m_fd > -1)
-        close(m_fd);
-#endif
 }
 
 native_symbol_type library::get_symbol(const char *symbol_name) const {
@@ -230,7 +248,13 @@ std::vector<symbol_info> library::symbols() const {
         throw std::logic_error("Attempted to use a moved library object");
 
     try {
-        internal_symbols = get_symbols(m_handle, DYLIB_WIN_MAC_OTHER(-1, m_fd, -1));
+#ifdef __APPLE__
+        scoped_fd fd(m_path);
+
+        internal_symbols = get_symbols(m_handle, fd.get());
+#else
+        internal_symbols = get_symbols(m_handle, -1);
+#endif
 
         symbols.reserve(internal_symbols.size());
 
@@ -254,7 +278,13 @@ std::vector<std::string> library::sections() const {
         throw std::logic_error("Attempted to use a moved library object");
 
     try {
-        return get_sections(m_handle, DYLIB_WIN_MAC_OTHER(-1, m_fd, m_fd));
+#ifdef _WIN32
+        return get_sections(m_handle, -1);
+#else
+        scoped_fd fd(m_path);
+
+        return get_sections(m_handle, fd.get());
+#endif
     } catch (const std::runtime_error &e) {
         throw section_collection_error(e.what());
     }

--- a/src/symbols.cpp
+++ b/src/symbols.cpp
@@ -385,9 +385,17 @@ std::vector<internal_symbol_info> get_symbols(void *handle, int fd) {
     if (!symtab || !strtab || symentries == 0)
         return symbols_list;
 
-    size = strtab - (char *)symtab;
+    /*
+     * The dynamic section does not record the size of the symbol table, so it is
+     * deduced from the fact that the string table usually directly follows it.
+     * Bail out instead of underflowing if a linker lays them out the other way.
+     */
+    if (strtab <= (const char *)symtab)
+        return symbols_list;
 
-    for (int i = 0; i < size / symentries; ++i) {
+    size = (unsigned long)(strtab - (char *)symtab);
+
+    for (unsigned long i = 0; i < size / symentries; ++i) {
         unsigned char type = DYLIB_ELF_ST_TYPE(symtab[i].st_info);
 
         /*

--- a/src/symbols.cpp
+++ b/src/symbols.cpp
@@ -388,10 +388,13 @@ std::vector<internal_symbol_info> get_symbols(void *handle, int fd) {
     size = strtab - (char *)symtab;
 
     for (int i = 0; i < size / symentries; ++i) {
-        ElfSym *sym = &symtab[i];
+        unsigned char type = DYLIB_ELF_ST_TYPE(symtab[i].st_info);
 
-        if (DYLIB_ELF_ST_TYPE(symtab[i].st_info) == STT_FUNC) {
-            const char *name = &strtab[sym->st_name];
+        /*
+         * Collect functions (STT_FUNC) and global variables (STT_OBJECT)
+         */
+        if (type == STT_FUNC || type == STT_OBJECT) {
+            const char *name = &strtab[symtab[i].st_name];
 
             add_symbol(symbols_list, name, !!dlsym(handle, name));
         }

--- a/tests/lib.cpp
+++ b/tests/lib.cpp
@@ -44,6 +44,8 @@ LIB_EXPORT void list_add_string(std::vector<std::string> &cont, std::string elem
 }
 
 namespace tools {
+LIB_EXPORT double pi_value = 3.14159;
+
 LIB_EXPORT double adder() {
     return 0;
 }

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -164,6 +164,13 @@ TEST(cpp_symbols, variables) {
     EXPECT_EQ(strcmp(secret, "12345"), 0);
 }
 
+TEST(cpp_symbols, variables_namespace) {
+    dylib::library lib("./dynamic_lib", dylib::decorations::os_default());
+
+    auto pi = lib.get_variable<double>("tools::pi_value");
+    EXPECT_EQ(pi, 3.14159);
+}
+
 TEST(cpp_symbols, functions) {
     dylib::library lib("./dynamic_lib", dylib::decorations::os_default());
 

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -298,8 +298,6 @@ TEST(cpp_symbols, demangle) {
     }
 }
 
-#include <iostream>
-
 TEST(sections, lookup) {
     dylib::library lib("./dynamic_lib", dylib::decorations::os_default());
     std::vector<std::string> sections;


### PR DESCRIPTION
Follow-ups from a review pass over the codebase after the section collection feature landed. One commit per issue to make review easier.

## Bug fix

**`symbols()` returned only functions on Linux** (`bc7d2ec`)

The ELF symbol collection filtered on `STT_FUNC`, while Windows (export directory) and macOS (`LC_SYMTAB`) both return variables too. As a result `get_symbol()` could never resolve a namespaced global variable through its demangled name fallback on Linux, even though the README documents exactly that usage.

Variables at global scope were unaffected, because the Itanium ABI leaves them unmangled and `dlsym` resolved them directly, which is why no test caught it. The `example/` program hits this: it calls `get_variable("example::magic")`.

Now collects `STT_OBJECT` as well, with a namespaced variable added to the test library.

## Other changes

| Commit | Change |
| --- | --- |
| `203b6d5` | `get_symbol()` re-demangled every symbol during its fallback, although `symbols()` already stores a `demangled_name`. On MSVC that meant four `UnDecorateSymbolName` calls per symbol instead of two. |
| `2846138` | Remove a stray unused `<iostream>` include sitting mid-file in the tests. |
| `2773130` | The version was hardcoded in six places with nothing keeping them in sync. `dylib.hpp` now exposes `DYLIB_VERSION_MAJOR/MINOR/PATCH` and CMake parses them from the header. The macros also let users feature-detect an API at compile time. Bumped to **3.1.0**, since `sections()`, `collection_error` and `section_collection_error` are new public API. |
| `41b8dab` | `native_handle()` is now `const`, like every other accessor. |
| `29e68c8` | The ELF symbol table size is deduced from the `DT_SYMTAB`/`DT_STRTAB` distance, which assumes an ordering the spec does not guarantee. The reverse layout underflowed into a huge unsigned value. Bails out instead, and iterates with a matching unsigned counter. |
| `aa3856a` | The POSIX constructor held a file descriptor for the whole library lifetime, though it is only needed by `symbols()` on macOS and `sections()` on macOS and Linux. Now opened through an RAII guard only while the file is read, so a process loading many plugins no longer pays a descriptor per library. |
| `4b50716` | The example was never built by CI and fetched a released tag rather than the local tree, so nothing kept it working. A new job overrides the fetch with `FETCHCONTENT_SOURCE_DIR_DYLIB` and builds/runs it against the branch on all three platforms. |

## Behavior change worth noting

`aa3856a` means the constructor no longer reports an unreadable library file. That error now surfaces from `symbols()` or `sections()`, the operations that actually need to read it.

## Validation

Locally on macOS: clean build with `DYLIB_WARNING_AS_ERRORS=ON` across C++11/14/17/20, all 19 tests pass, clang-format and clang-tidy clean, and the example builds and runs against the local tree. The descriptor change was verified by inspecting `/dev/fd` before and after `symbols()`/`sections()`.

The Linux and Windows legs are unverified locally and rely on CI. The new Windows `example` job in particular is unproven; if it trips, the likely cause is the binary path or the DLL-next-to-exe assumption rather than library code.